### PR TITLE
fix altaz orientation

### DIFF
--- a/include/citlali/core/engine/engine.h
+++ b/include/citlali/core/engine/engine.h
@@ -388,7 +388,7 @@ void Engine::obsnum_setup() {
 
     // setup kernel
     if (rtcproc.run_kernel) {
-        rtcproc.kernel.setup(n_maps);
+        rtcproc.kernel.setup(n_maps, telescope.pixel_axes);
     }
 
     // set despiker sample rate
@@ -1007,7 +1007,7 @@ void Engine::create_obs_map_files() {
                                                   engine_utils::toltecIO::raw>(obsnum_dir_name + "raw/", redu_type, array_name,
                                                                                obsnum, telescope.sim_obs);
         // create fits_io class for current array file
-        fitsIO<file_type_enum::write_fits, CCfits::ExtHDU*> fits_io(filename);
+        fitsIO<file_type_enum::write_fits, CCfits::ExtHDU*> fits_io(filename, telescope.pixel_axes);
         // append to fits_io vector
         fits_io_vec.push_back(std::move(fits_io));
 
@@ -1019,7 +1019,7 @@ void Engine::create_obs_map_files() {
                                                           engine_utils::toltecIO::raw>(obsnum_dir_name + "raw/", redu_type, array_name,
                                                                                        obsnum, telescope.sim_obs);
                 // create fits_io class for current array file
-                fitsIO<file_type_enum::write_fits, CCfits::ExtHDU*> fits_io(filename);
+                fitsIO<file_type_enum::write_fits, CCfits::ExtHDU*> fits_io(filename, telescope.pixel_axes);
                 // append to fits_io vector
                 noise_fits_io_vec.push_back(std::move(fits_io));
             }
@@ -1032,7 +1032,7 @@ void Engine::create_obs_map_files() {
                                                                                             redu_type, array_name,
                                                                                             obsnum, telescope.sim_obs);
                 // create fits_io class for current array file
-                fitsIO<file_type_enum::write_fits, CCfits::ExtHDU*> fits_io(filename);
+                fitsIO<file_type_enum::write_fits, CCfits::ExtHDU*> fits_io(filename, telescope.pixel_axes);
                 // append to fits_io vector
                 filtered_fits_io_vec.push_back(std::move(fits_io));
 
@@ -1043,7 +1043,7 @@ void Engine::create_obs_map_files() {
                                                               engine_utils::toltecIO::filtered>(obsnum_dir_name + "filtered/", redu_type,
                                                                                                 array_name, obsnum, telescope.sim_obs);
                     // create fits_io class for current array file
-                    fitsIO<file_type_enum::write_fits, CCfits::ExtHDU*> fits_io(filename);
+                    fitsIO<file_type_enum::write_fits, CCfits::ExtHDU*> fits_io(filename, telescope.pixel_axes);
                     // append to fits_io vector
                     filtered_noise_fits_io_vec.push_back(std::move(fits_io));
                 }

--- a/include/citlali/core/engine/todproc.h
+++ b/include/citlali/core/engine/todproc.h
@@ -1409,7 +1409,7 @@ void TimeOrderedDataProc<EngineType>::create_coadded_map_files() {
                                                                                                  "", array_name, "",
                                                                                                  engine().telescope.sim_obs);
         // create fits_io class for current array file
-        fitsIO<file_type_enum::write_fits, CCfits::ExtHDU*> fits_io(filename);
+        fitsIO<file_type_enum::write_fits, CCfits::ExtHDU*> fits_io(filename, engine().telescope.pixel_axes);
         // append to fits_io vector
         engine().coadd_fits_io_vec.push_back(std::move(fits_io));
 
@@ -1421,7 +1421,7 @@ void TimeOrderedDataProc<EngineType>::create_coadded_map_files() {
                                                                                                      "", array_name, "",
                                                                                                      engine().telescope.sim_obs);
             // create fits_io class for current array file
-            fitsIO<file_type_enum::write_fits, CCfits::ExtHDU*> fits_io(filename);
+            fitsIO<file_type_enum::write_fits, CCfits::ExtHDU*> fits_io(filename, engine().telescope.pixel_axes);
             // append to fits_io vector
             engine().coadd_noise_fits_io_vec.push_back(std::move(fits_io));
         }
@@ -1441,7 +1441,7 @@ void TimeOrderedDataProc<EngineType>::create_coadded_map_files() {
                                                                                                           "filtered/","", array_name,
                                                                                                           "", engine().telescope.sim_obs);
             // create fits_io class for current array file
-            fitsIO<file_type_enum::write_fits, CCfits::ExtHDU*> fits_io(filename);
+            fitsIO<file_type_enum::write_fits, CCfits::ExtHDU*> fits_io(filename, engine().telescope.pixel_axes);
             // append to fits_io vector
             engine().filtered_coadd_fits_io_vec.push_back(std::move(fits_io));
 
@@ -1453,7 +1453,7 @@ void TimeOrderedDataProc<EngineType>::create_coadded_map_files() {
                                                                                                               "filtered/","", array_name,
                                                                                                               "", engine().telescope.sim_obs);
                 // create fits_io class for current array file
-                fitsIO<file_type_enum::write_fits, CCfits::ExtHDU*> fits_io(filename);
+                fitsIO<file_type_enum::write_fits, CCfits::ExtHDU*> fits_io(filename, engine().telescope.pixel_axes);
                 // append to fits_io vector
                 engine().filtered_coadd_noise_fits_io_vec.push_back(std::move(fits_io));
             }

--- a/include/citlali/core/timestream/rtc/kernel.h
+++ b/include/citlali/core/timestream/rtc/kernel.h
@@ -28,7 +28,7 @@ public:
     std::string map_grouping;
 
     // initial setup
-    void setup(Eigen::Index);
+    void setup(Eigen::Index, std::string);
 
     // symmetric gaussian kernel
     template<typename apt_t>
@@ -47,14 +47,14 @@ public:
                                  apt_t &, double, Eigen::DenseBase<Derived> &);
 };
 
-void Kernel::setup(Eigen::Index n_maps) {
+void Kernel::setup(Eigen::Index n_maps, std::string pixel_axes) {
     if (type == "fits") {
         if (img_ext_names.size()!=n_maps && img_ext_names.size()!=1) {
             SPDLOG_INFO("mismatch for number of kernel images");
             std::exit(EXIT_FAILURE);
         }
 
-        fitsIO<file_type_enum::read_fits, CCfits::ExtHDU*> fits_io(filepath);
+        fitsIO<file_type_enum::read_fits, CCfits::ExtHDU*> fits_io(filepath, pixel_axes);
         for (auto & img_ext_name : img_ext_names) {
             images.push_back(fits_io.get_hdu(img_ext_name));
         }

--- a/include/citlali/core/timestream/timestream.h
+++ b/include/citlali/core/timestream/timestream.h
@@ -306,7 +306,7 @@ public:
 
     // create a map buffer from a citlali reduction directory
     template <class calib_t>
-    void load_mb(std::string, std::string, calib_t &);
+    void load_mb(std::string, std::string, calib_t &, std::string);
 
     // get limits for a particular grouping
     template <class calib_t>
@@ -344,7 +344,7 @@ public:
 };
 
 template <class calib_t>
-void TCProc::load_mb(std::string filepath, std::string noise_filepath, calib_t &calib) {
+void TCProc::load_mb(std::string filepath, std::string noise_filepath, calib_t &calib, std::string pixel_axes) {
 
     namespace fs = std::filesystem;
 
@@ -388,7 +388,7 @@ void TCProc::load_mb(std::string filepath, std::string noise_filepath, calib_t &
                     // get maps (if noise not in filename)
                     if (filename.find("noise") == std::string::npos) {
                         // get fits file
-                        fitsIO<file_type_enum::read_fits, CCfits::ExtHDU*> fits_io(entry.path().string());
+                        fitsIO<file_type_enum::read_fits, CCfits::ExtHDU*> fits_io(entry.path().string(), pixel_axes);
 
                         // get number of extensions other than primary extension
                         int num_extensions = 0;
@@ -471,7 +471,7 @@ void TCProc::load_mb(std::string filepath, std::string noise_filepath, calib_t &
                     // check if the current file is a noise map
                     if (filename.find("_noise_citlali.fits") != std::string::npos) {
                         // get fits file
-                        fitsIO<file_type_enum::read_fits, CCfits::ExtHDU*> fits_io(entry.path().string());
+                        fitsIO<file_type_enum::read_fits, CCfits::ExtHDU*> fits_io(entry.path().string(), pixel_axes);
 
                         // get number of noise maps
                         int num_extensions = 0;

--- a/include/citlali/core/utils/fits_io.h
+++ b/include/citlali/core/utils/fits_io.h
@@ -21,10 +21,12 @@ public:
     // vector of hdu's for easy access
     std::vector<ext_hdu_t> hdus;
 
+    std::string pixel_axes;
+
     fitsIO() {}
 
     // constructor
-    fitsIO(std::string _f) : filepath(_f) {
+    fitsIO(std::string _f, std::string _a) : filepath(_f), pixel_axes(_a) {
         // read in file
         if constexpr (file_type==file_type_enum::read_fits) {
             try {
@@ -63,11 +65,17 @@ public:
         // valarray to copy data into (seems to be necessary)
         std::valarray<double> temp_data(data.size());
 
-        // copy the data (flip in x direction)
+        // copy the data
         int k = 0;
         for (int i=0; i<data.rows(); ++i){
             for (int j=0; j<data.cols(); ++j) {
-                temp_data[k] = data(i, data.cols() - j - 1);
+                if (pixel_axes != "altaz") {
+                    // flip in x direction)
+                    temp_data[k] = data(i, data.cols() - j - 1);
+                }
+                else {
+                    temp_data[k] = data(i,j);
+                }
                 k++;
             }
         }
@@ -108,7 +116,9 @@ public:
             }
 
             // flip to match internal orientation
-            data.rowwise().reverseInPlace();
+            if (pixel_axes != "altaz") {
+                data.rowwise().reverseInPlace();
+            }
 
             return data;
 

--- a/src/citlali/cli/main.cpp
+++ b/src/citlali/cli/main.cpp
@@ -787,7 +787,8 @@ int run(const rc_t &rc) {
                                     // set coverage region
                                     todproc.engine().ptcproc.tod_mb.cov_cut = todproc.engine().omb.cov_cut;
                                     // get map buffer from from path even if only saving last iteration
-                                    todproc.engine().ptcproc.load_mb(fruit_dir, fruit_dir, todproc.engine().calib);
+                                    todproc.engine().ptcproc.load_mb(fruit_dir, fruit_dir, todproc.engine().calib,
+                                                                    todproc.engine().telescope.pixel_axes);
                                 }
                             }
 
@@ -846,7 +847,8 @@ int run(const rc_t &rc) {
 
                                 // get map buffer from reduction directory
                                 logger->info("reading in {} for fruit loops iteration {}",fruit_dir, todproc.engine().fruit_iter);
-                                todproc.engine().ptcproc.load_mb(fruit_dir, fruit_dir, todproc.engine().calib);
+                                todproc.engine().ptcproc.load_mb(fruit_dir, fruit_dir, todproc.engine().calib,
+                                                                todproc.engine().telescope.pixel_axes);
                             }
                         }
 

--- a/src/citlali/core/mapmaking/map.cpp
+++ b/src/citlali/core/mapmaking/map.cpp
@@ -33,7 +33,12 @@ void MapBuffer::get_config(tula::config::YamlConfig &config, std::vector<std::ve
     pixel_size_rad *= ASEC_TO_RAD;
 
     // set wcs cdelt for cols
-    wcs.cdelt.push_back(-pixel_size_rad);
+    if (pixel_axes == "radec" || pixel_axes == "galactic") {
+        wcs.cdelt.push_back(-pixel_size_rad);
+    }
+    else {
+        wcs.cdelt.push_back(pixel_size_rad);
+    }
     // set wcs cdelt for rows
     wcs.cdelt.push_back(pixel_size_rad);
 
@@ -97,7 +102,7 @@ void MapBuffer::get_config(tula::config::YamlConfig &config, std::vector<std::ve
         }
     }
 
-    // setup wcs altaz frame
+    // setup wcs galactic frame
     else if (pixel_axes == "galactic") {
         wcs.ctype.push_back("GLON-TAN");
         wcs.ctype.push_back("GLAT-TAN");


### PR DESCRIPTION
Internally, citlali stores maps in the array orientation with index (0,0) being the minimum coordinate value in both coordinates.  It then reverses rows and uses CDELT1 < 0 for radec maps.  This is incorrect for altaz maps though which do not need flipping in either coordinate.

This does not affect the measured offsets in altaz since they are consistent internally.